### PR TITLE
feat: add blob availability check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitcoin_da_client"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-trait",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_da_client"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 authors = ["SYS LABS sidhujag@syscoin.org"]
 description = "Tools for interacting with BitcoinDA by SYS LABS"

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Contributions are welcome! Please open an issue or submit a pull request for any
 
 ## Contact
 
-For any inquiries or feedback, please reach out to the maintainer at [abdul@syscoin.org](mailto:abdul@syscoin.org).
+For any inquiries or feedback, please reach out to the maintainer at [sidhujag@syscoin.org](mailto:sidhujag@syscoin.org).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ For any inquiries or feedback, please reach out to the maintainer at [abdul@sysc
 
 ## Support
 
-If you encounter any issues or have questions, feel free to open an issue on the [GitHub repository](https://github.com/SYS-Labs/bitcoin_da_client) or contact the maintainer directly.
+If you encounter any issues or have questions, feel free to open an issue on the [GitHub repository](https://github.com/syscoin/bitcoin_da_client) or contact the maintainer directly.
 
 ---
 

--- a/demo/DEMO.md
+++ b/demo/DEMO.md
@@ -173,5 +173,5 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Contact
 
-Maintainer: Abdul ([abdul@syscoin.org](mailto:abdul@syscoin.org))
+Maintainer: Jag ([sidhujag@syscoin.org](mailto:sidhuag@syscoin.org))
 GitHub: [https://github.com/syscoin/bitcoin\_da\_client](https://github.com/syscoin/bitcoin_da_client)

--- a/demo/DEMO.md
+++ b/demo/DEMO.md
@@ -174,4 +174,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ## Contact
 
 Maintainer: Abdul ([abdul@syscoin.org](mailto:abdul@syscoin.org))
-GitHub: [https://github.com/SYS-Labs/bitcoin\_da\_client](https://github.com/SYS-Labs/bitcoin_da_client)
+GitHub: [https://github.com/syscoin/bitcoin\_da\_client](https://github.com/syscoin/bitcoin_da_client)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,7 +348,7 @@ impl SyscoinClient {
         // pass positional args: data hex, overwrite_existing, hash type.
         // Keep overwrite_existing=false to make repeated calls idempotent for identical data.
         // Force blake2s to keep blob IDs aligned with Syscoin / OS expectations.
-       // let params = vec![json!(data_hex), json!(false), json!("blake2s")];
+        // let params = vec![json!(data_hex), json!(false), json!("blake2s")];
         let params = vec![json!(data_hex), json!(false), json!("keccak")];
         // SYSCOIN
         let response = self
@@ -537,6 +537,28 @@ impl SyscoinClient {
         Err(last_err.unwrap_or_else(|| "failed to build PODA URL".into()))
     }
 
+    /// Check whether a blob is retrievable from the Syscoin node or PODA cloud storage.
+    ///
+    /// This is an availability check only. It deliberately does not imply chainlock or
+    /// confirmation finality.
+    pub async fn blob_exists(&self, blob_id: &str) -> Result<bool, SyscoinError> {
+        let actual_blob_id = blob_id.strip_prefix("0x").unwrap_or(blob_id);
+        let params = vec![json!(actual_blob_id)];
+
+        match self.rpc_client.call("getnevmblobdata", &params).await {
+            Ok(_) => Ok(true),
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("Could not find blob information for versionhash")
+                    || msg.contains("\"code\":-32602")
+                {
+                    return Ok(self.blob_exists_in_cloud(actual_blob_id).await);
+                }
+                Err(e)
+            }
+        }
+    }
+
     /// Check if a blob is final
     pub async fn check_blob_finality(&self, blob_id: &str) -> Result<bool, SyscoinError> {
         // Strip any 0x prefix
@@ -692,5 +714,29 @@ impl RpcClient for MockRpcClient {
 
     async fn http_get(&self, _url: &str) -> Result<Vec<u8>, SyscoinError> {
         Ok(b"mock_data".to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::Server;
+
+    #[tokio::test]
+    async fn blob_exists_does_not_imply_finality() {
+        let mut server = Server::new_async().await;
+        let _lookup = server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(r#"{"jsonrpc":"2.0","id":1,"result":{"data":"00","chainlock":false}}"#)
+            .expect(2)
+            .create_async()
+            .await;
+        let client = SyscoinClient::new(&server.url(), "user", "password", &server.url(), None, "")
+            .expect("client should initialize");
+
+        assert!(client.blob_exists("abc").await.unwrap());
+        assert!(!client.check_blob_finality("abc").await.unwrap());
     }
 }

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -549,6 +549,7 @@ mod tests {
             result.unwrap(),
             "Expected PODA fallback to mark blob as final"
         );
+        assert!(client.blob_exists(blob_id).await.unwrap());
     }
 
     #[tokio::test]
@@ -758,6 +759,7 @@ mod tests {
             result.unwrap(),
             "Expected PODA fallback to mark blob as final"
         );
+        assert!(client.blob_exists(blob_id).await.unwrap());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Add `SyscoinClient::blob_exists` for retrievability checks that do not imply DA finality.
- Keep PODA/archive fallback behavior for finality paths and add tests covering the distinction.
- Bump crate version to `0.1.10` for release tagging.

## Test plan
- `cargo test`


Made with [Cursor](https://cursor.com)